### PR TITLE
ci: remove npm token config from publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org/"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Removes setup-node registry-url from the trusted publishing workflow so npm can use GitHub OIDC instead of token-style npmrc auth.\n\nVerification:\n- pnpm run build\n- pnpm run format:check