### PR TITLE
chore(examples): bump axie-tools to 1.8.0

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axie-tools": "^1.7.7",
+        "axie-tools": "^1.8.0",
         "dotenv": "^17.4.2",
         "ethers": "^6.16.0"
       },
@@ -98,22 +98,35 @@
       "license": "MIT"
     },
     "node_modules/axie-tools": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axie-tools/-/axie-tools-1.7.7.tgz",
-      "integrity": "sha512-BlgDLUlezQzJ3EOBH+wGELdMvnsluYgBT93UmvEyyF83NB5yXGyI2hjdlsaaCTE0PUkQ0U5lNULmQbfQpkxeuQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/axie-tools/-/axie-tools-1.8.0.tgz",
+      "integrity": "sha512-JrIGo30BPpgDzvbJV9pL26d1Rb9weyPbv1pdCbq6POzuw/RdgeNeZJmTODF6M6G2trMPe0qR7oYzuJR/ikR2wA==",
       "license": "MIT",
       "dependencies": {
         "@roninbuilders/contracts": "^0.6.8",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.4.2",
         "ethers": "^6.13.4",
         "prompts": "^2.4.2",
-        "typescript": "^5.1.6"
+        "typescript": "^6.0.3"
       },
       "bin": {
         "axie-tools": "dist/cli.js"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/axie-tools/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/dotenv": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,7 +16,7 @@
     "ws": "8.20.1"
   },
   "dependencies": {
-    "axie-tools": "^1.7.7",
+    "axie-tools": "^1.8.0",
     "dotenv": "^17.4.2",
     "ethers": "^6.16.0"
   }

--- a/examples/transfer-all.js
+++ b/examples/transfer-all.js
@@ -1,4 +1,4 @@
-import { utils, Wallet, formatEther } from "ethers";
+import { isAddress, Wallet, formatEther } from "ethers";
 import {
   getAxieIdsFromAccount,
   batchTransferAxies,
@@ -37,7 +37,7 @@ async function batchTransfer() {
   }
 
   const toAddress = args[0].replace("ronin:", "0x");
-  if (!utils.isAddress(toAddress)) {
+  if (!isAddress(toAddress)) {
     throw new Error("Invalid recipient address");
   }
 


### PR DESCRIPTION
## Summary\n- Update examples package dependency to axie-tools@^1.8.0.\n- Bump lockfile accordingly.\n- Fix ethers v6 API compatibility in examples/transfer-all.js (use isAddress import).\n\n## Verification\n- Local repo-level diff confirmed only intended files changed.\n