### PR TITLE
fix(deps): remediate ws memory exhaustion alert

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -257,9 +257,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "license": "ISC",
   "overrides": {
-    "ws": "8.20.1"
+    "ws": "8.21.0"
   },
   "dependencies": {
     "axie-tools": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "pnpm": {
     "overrides": {
-      "ws": "8.20.1"
+      "ws": "8.21.0"
     }
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  ws: 8.20.1
+  ws: 8.21.0
 
 importers:
 
@@ -355,8 +355,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -564,7 +564,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -597,4 +597,4 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}


### PR DESCRIPTION
## Summary

- Upgrade the root pnpm override and lockfile from ws 8.20.1 to 8.21.0.
- Upgrade the examples npm override and lockfile from ws 8.20.1 to 8.21.0.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run format:check`
- `pnpm build`
- Read-only floor/list tests: 4 passed
- `npm ci --ignore-scripts --no-audit --no-fund` in examples
- Root and examples dependency trees resolve ws 8.21.0

## Safety

- No live marketplace write operations were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled WebSocket component to version 8.21.0.
  * Applied the same update across example projects for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->