### PR TITLE
docs(release): adapt Autoship workflow

### DIFF
--- a/.agents/skills/autoship/SKILL.md
+++ b/.agents/skills/autoship/SKILL.md
@@ -1,216 +1,79 @@
 ---
 name: autoship
-description: CLI tool for automated changeset-based releases with AI-generated descriptions. Use when the user needs to release a package, create changesets, bump versions, or automate npm publishing workflows. Triggers include requests to "release a package", "create a changeset", "publish to npm", "bump the version", "automate releases", or any task involving version management and package publishing for repositories using the changesets workflow.
-allowed-tools: Bash(autoship:*), Bash(npx autoship:*), Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(node:*), Bash(rg:*)
+description: Automate package releases with Autoship in Changesets repositories, or follow a documented repository-native release path when Autoship is incompatible.
+allowed-tools: Bash(npx autoship@0.1.0:*), Bash(test:*), Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(node:*), Bash(rg:*), Bash(jq:*), Bash(mktemp:*)
 ---
 
-# Automated Releases with autoship
+# Automated Releases with Autoship
 
-## Compatibility Check
+Autoship 0.1.0 assumes the configured target repository uses Changesets. Treat
+version preparation, PR merging, and npm publishing as separate external
+mutations. Confirm that the user's request authorizes each mutation before it
+runs; `--yes` removes CLI prompts but never grants authorization.
 
-Before running a mutating `autoship <repo>` command, verify that the target
-repository actually uses Changesets:
+## Route the target
+
+Before any mutating Autoship command:
+
+1. Read the repository alias from `~/.autoship/config.json` and resolve its
+   `cloneUrl` and `baseBranch`.
+2. Clone that exact target and branch into a temporary checkout.
+3. Run all compatibility checks inside that checkout:
 
 ```bash
 test -f .changeset/config.json
-node -e "const p=require('./package.json'); process.exit(p.devDependencies?.['@changesets/cli'] ? 0 : 1)"
-rg "changesets/action" .github/workflows
+node -e \
+  "const p=require('./package.json');
+  process.exit(p.devDependencies?.['@changesets/cli'] ? 0 : 1)"
+rg 'changesets/action' .github/workflows
 ```
 
-If any of those integration points are absent, do not run the stock release
-command and do not add Changesets just to satisfy this skill. Inspect the
-repository's existing release workflows and adapt the sequence to them. Keep
-version preparation and package publishing as separate mutating boundaries,
-and require explicit user authorization for each unless the current request
-already grants it. Never use `--yes` to bypass an authorization boundary.
+Do not run the mutating stock command unless all three checks pass in the
+configured target. Never add Changesets merely to satisfy this skill. Inspect
+the target's existing release workflows and use a documented repository-native
+route when any check fails.
 
-Axie Tools is a documented non-Changesets target. Follow
-[references/axie-tools.md](references/axie-tools.md) instead of the stock
-10-step flow.
+Axie Tools is a documented non-Changesets target. Read and follow
+[references/axie-tools.md](references/axie-tools.md).
 
-## Core Workflow
+## Compatible Changesets repositories
 
-For repositories that pass the Changesets compatibility check, every release
-follows this pattern:
-
-Every release follows this pattern:
-
-1. **Configure**: `autoship add <name>` (one-time setup)
-2. **Release**: `autoship <name>` (interactive) or `autoship <name> -t patch -y` (automated)
-
-The tool handles the complete release cycle:
-- Clone repository
-- Analyze changes and suggest release type (patch/minor/major)
-- Generate AI-powered changeset description
-- Create and merge changeset PR
-- Wait for and merge Version Packages PR
-- Trigger npm publish
-
-## Requirements
-
-Before using autoship, ensure:
+Read [references/configuration.md](references/configuration.md) before first-time
+setup and [references/commands.md](references/commands.md) for CLI details.
 
 ```bash
-# GitHub CLI must be authenticated
-gh auth login
+# One-time interactive configuration
+npx autoship@0.1.0 add myproject
 
-# API key for AI features
-export AI_GATEWAY_API_KEY="your-key"
+# Interactive release
+npx autoship@0.1.0 myproject
+
+# Authorized, non-interactive patch release with a reviewed message
+npx autoship@0.1.0 myproject -t patch -m "Fix release issue" -y
 ```
 
-## Essential Commands
+Omit `-m` only when `AI_GATEWAY_API_KEY` is available and AI-generated release
+text is wanted. Use [references/ci-integration.md](references/ci-integration.md)
+only when building CI for a compatible Changesets repository.
 
-```bash
-# One-time setup: add a repository
-autoship add myproject
-# Prompts for: owner, repo name, base branch
+## Completion
 
-# List configured repositories
-autoship list
+Autoship clones the target, creates and merges a Changesets PR, waits for the
+Version Packages PR, and merges that PR to trigger publishing. Do not report
+success until the package version, dist-tag, Git tag, GitHub release, and source
+commit independently agree. Report partial state exactly and do not retry a
+publish blindly after npm accepted a package.
 
-# Interactive release (prompts for type and message)
-autoship myproject
+Typical successful output ends with:
 
-# Automated release (no prompts)
-autoship myproject -t patch -y
-autoship myproject -t minor -y
-autoship myproject -t major -y
-
-# Release with custom message (skips AI generation)
-autoship myproject -t patch -m "Fixed login bug" -y
-```
-
-## Command Options
-
-```bash
-autoship [repo]                    # Interactive repo selection if omitted
-  -t, --type <type>                # Release type: patch, minor, major
-  -m, --message <message>          # Custom changeset description
-  -y, --yes                        # Skip all confirmations
-  -h, --help                       # Show help
-```
-
-## Common Patterns
-
-### Fully Automated Patch Release
-
-```bash
-autoship myproject -t patch -y
-```
-
-### AI-Assisted Interactive Release
-
-```bash
-autoship myproject
-# 1. AI analyzes commits since last release
-# 2. AI suggests release type (patch/minor/major)
-# 3. You confirm or change the type
-# 4. AI generates changeset description
-# 5. You review and approve
-# 6. Tool handles PR creation and merging
-```
-
-### Custom Message Release
-
-```bash
-autoship myproject -t minor -m "Added new authentication providers" -y
-```
-
-### CI/CD Integration
-
-```bash
-# In GitHub Actions or CI pipeline
-export AI_GATEWAY_API_KEY="${{ secrets.AI_GATEWAY_API_KEY }}"
-npx autoship myproject -t patch -y
-```
-
-## What autoship Does (10 Steps)
-
-These steps apply only to compatible Changesets repositories:
-
-1. **Clone** - Clones the repository from the base branch
-2. **Analyze** - Finds latest version tag, analyzes commits and diff
-3. **Suggest** - AI suggests release type based on changes
-4. **Generate** - AI generates changeset description
-5. **Branch** - Creates release branch with changeset file
-6. **PR** - Creates pull request for the changeset
-7. **Wait** - Waits for CI checks to pass
-8. **Merge** - Merges the changeset PR
-9. **Version PR** - Waits for changesets action to create Version Packages PR
-10. **Publish** - Merges Version Packages PR to trigger npm publish
-
-## Output Format
-
-autoship provides clear step-by-step output:
-
-```
-[1/10] Cloning repository from main...
-  > Repository cloned
-  > Package: my-package @ 1.2.3
-
-[2/10] Creating release branch...
-  > Branch created: release/patch-1706123456789
-
-[3/10] Generating changeset...
-  > Changeset created: fluffy-pants-dance.md
-
-...
-
+```text
 Release Complete!
 The patch release has been published.
 ```
 
-## Configuration
+## Templates
 
-Config is stored at `~/.autoship/config.json`:
-
-```json
-{
-  "repos": {
-    "myproject": {
-      "owner": "vercel-labs",
-      "repo": "myproject",
-      "baseBranch": "main",
-      "cloneUrl": "https://github.com/vercel-labs/myproject.git"
-    }
-  }
-}
-```
-
-## Deep-Dive Documentation
-
-| Reference | When to Use |
-|-----------|-------------|
-| [references/commands.md](references/commands.md) | Full command reference with all options |
-| [references/configuration.md](references/configuration.md) | Config file format and repository setup |
-| [references/ci-integration.md](references/ci-integration.md) | GitHub Actions and CI/CD setup |
-
-## Ready-to-Use Templates
-
-| Template | Description |
-|----------|-------------|
-| [templates/automated-release.sh](templates/automated-release.sh) | Fully automated release script |
-| [templates/setup-repo.sh](templates/setup-repo.sh) | Non-interactive repository setup |
-
-```bash
-./templates/automated-release.sh myproject patch
-./templates/setup-repo.sh myproject vercel-labs myproject main
-```
-
-## Troubleshooting
-
-### "No repositories configured"
-
-Run `autoship add <name>` to configure a repository first.
-
-### "Repository not found"
-
-Check `autoship list` for available repos. The name is case-sensitive.
-
-### CI checks failing
-
-The tool will show which checks failed. Fix the issues in the target repository, then retry.
-
-### AI generation failed
-
-If AI fails, autoship falls back to manual input. Ensure `AI_GATEWAY_API_KEY` is set.
+- [templates/setup-repo.sh](templates/setup-repo.sh) writes configuration
+  non-interactively and requires `jq`.
+- [templates/automated-release.sh](templates/automated-release.sh) runs an
+  already-authorized compatible release with Autoship 0.1.0.

--- a/.agents/skills/autoship/SKILL.md
+++ b/.agents/skills/autoship/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: autoship
+description: CLI tool for automated changeset-based releases with AI-generated descriptions. Use when the user needs to release a package, create changesets, bump versions, or automate npm publishing workflows. Triggers include requests to "release a package", "create a changeset", "publish to npm", "bump the version", "automate releases", or any task involving version management and package publishing for repositories using the changesets workflow.
+allowed-tools: Bash(autoship:*), Bash(npx autoship:*), Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(node:*), Bash(rg:*)
+---
+
+# Automated Releases with autoship
+
+## Compatibility Check
+
+Before running a mutating `autoship <repo>` command, verify that the target
+repository actually uses Changesets:
+
+```bash
+test -f .changeset/config.json
+node -e "const p=require('./package.json'); process.exit(p.devDependencies?.['@changesets/cli'] ? 0 : 1)"
+rg "changesets/action" .github/workflows
+```
+
+If any of those integration points are absent, do not run the stock release
+command and do not add Changesets just to satisfy this skill. Inspect the
+repository's existing release workflows and adapt the sequence to them. Keep
+version preparation and package publishing as separate mutating boundaries,
+and require explicit user authorization for each unless the current request
+already grants it. Never use `--yes` to bypass an authorization boundary.
+
+Axie Tools is a documented non-Changesets target. Follow
+[references/axie-tools.md](references/axie-tools.md) instead of the stock
+10-step flow.
+
+## Core Workflow
+
+For repositories that pass the Changesets compatibility check, every release
+follows this pattern:
+
+Every release follows this pattern:
+
+1. **Configure**: `autoship add <name>` (one-time setup)
+2. **Release**: `autoship <name>` (interactive) or `autoship <name> -t patch -y` (automated)
+
+The tool handles the complete release cycle:
+- Clone repository
+- Analyze changes and suggest release type (patch/minor/major)
+- Generate AI-powered changeset description
+- Create and merge changeset PR
+- Wait for and merge Version Packages PR
+- Trigger npm publish
+
+## Requirements
+
+Before using autoship, ensure:
+
+```bash
+# GitHub CLI must be authenticated
+gh auth login
+
+# API key for AI features
+export AI_GATEWAY_API_KEY="your-key"
+```
+
+## Essential Commands
+
+```bash
+# One-time setup: add a repository
+autoship add myproject
+# Prompts for: owner, repo name, base branch
+
+# List configured repositories
+autoship list
+
+# Interactive release (prompts for type and message)
+autoship myproject
+
+# Automated release (no prompts)
+autoship myproject -t patch -y
+autoship myproject -t minor -y
+autoship myproject -t major -y
+
+# Release with custom message (skips AI generation)
+autoship myproject -t patch -m "Fixed login bug" -y
+```
+
+## Command Options
+
+```bash
+autoship [repo]                    # Interactive repo selection if omitted
+  -t, --type <type>                # Release type: patch, minor, major
+  -m, --message <message>          # Custom changeset description
+  -y, --yes                        # Skip all confirmations
+  -h, --help                       # Show help
+```
+
+## Common Patterns
+
+### Fully Automated Patch Release
+
+```bash
+autoship myproject -t patch -y
+```
+
+### AI-Assisted Interactive Release
+
+```bash
+autoship myproject
+# 1. AI analyzes commits since last release
+# 2. AI suggests release type (patch/minor/major)
+# 3. You confirm or change the type
+# 4. AI generates changeset description
+# 5. You review and approve
+# 6. Tool handles PR creation and merging
+```
+
+### Custom Message Release
+
+```bash
+autoship myproject -t minor -m "Added new authentication providers" -y
+```
+
+### CI/CD Integration
+
+```bash
+# In GitHub Actions or CI pipeline
+export AI_GATEWAY_API_KEY="${{ secrets.AI_GATEWAY_API_KEY }}"
+npx autoship myproject -t patch -y
+```
+
+## What autoship Does (10 Steps)
+
+These steps apply only to compatible Changesets repositories:
+
+1. **Clone** - Clones the repository from the base branch
+2. **Analyze** - Finds latest version tag, analyzes commits and diff
+3. **Suggest** - AI suggests release type based on changes
+4. **Generate** - AI generates changeset description
+5. **Branch** - Creates release branch with changeset file
+6. **PR** - Creates pull request for the changeset
+7. **Wait** - Waits for CI checks to pass
+8. **Merge** - Merges the changeset PR
+9. **Version PR** - Waits for changesets action to create Version Packages PR
+10. **Publish** - Merges Version Packages PR to trigger npm publish
+
+## Output Format
+
+autoship provides clear step-by-step output:
+
+```
+[1/10] Cloning repository from main...
+  > Repository cloned
+  > Package: my-package @ 1.2.3
+
+[2/10] Creating release branch...
+  > Branch created: release/patch-1706123456789
+
+[3/10] Generating changeset...
+  > Changeset created: fluffy-pants-dance.md
+
+...
+
+Release Complete!
+The patch release has been published.
+```
+
+## Configuration
+
+Config is stored at `~/.autoship/config.json`:
+
+```json
+{
+  "repos": {
+    "myproject": {
+      "owner": "vercel-labs",
+      "repo": "myproject",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel-labs/myproject.git"
+    }
+  }
+}
+```
+
+## Deep-Dive Documentation
+
+| Reference | When to Use |
+|-----------|-------------|
+| [references/commands.md](references/commands.md) | Full command reference with all options |
+| [references/configuration.md](references/configuration.md) | Config file format and repository setup |
+| [references/ci-integration.md](references/ci-integration.md) | GitHub Actions and CI/CD setup |
+
+## Ready-to-Use Templates
+
+| Template | Description |
+|----------|-------------|
+| [templates/automated-release.sh](templates/automated-release.sh) | Fully automated release script |
+| [templates/setup-repo.sh](templates/setup-repo.sh) | Non-interactive repository setup |
+
+```bash
+./templates/automated-release.sh myproject patch
+./templates/setup-repo.sh myproject vercel-labs myproject main
+```
+
+## Troubleshooting
+
+### "No repositories configured"
+
+Run `autoship add <name>` to configure a repository first.
+
+### "Repository not found"
+
+Check `autoship list` for available repos. The name is case-sensitive.
+
+### CI checks failing
+
+The tool will show which checks failed. Fix the issues in the target repository, then retry.
+
+### AI generation failed
+
+If AI fails, autoship falls back to manual input. Ensure `AI_GATEWAY_API_KEY` is set.

--- a/.agents/skills/autoship/references/axie-tools.md
+++ b/.agents/skills/autoship/references/axie-tools.md
@@ -49,7 +49,9 @@ gh workflow run release.yml --ref main -f release_type=patch
 
 Use `minor` or `major` only when the audited delta and user authorization call
 for it. The workflow runs `pnpm version --no-git-tag-version`, pushes
-`release/v<new-version>`, and opens a PR containing the `package.json` bump.
+`release/v<new-version>`, opens a PR containing the `package.json` bump, and
+dispatches CI against that exact release commit. The preparation workflow does
+not succeed until the dispatched CI run passes.
 
 Wait for the workflow to complete, then verify the generated PR before merging:
 
@@ -67,13 +69,20 @@ Publishing is destructive and externally visible. After explicit authorization
 and all version-PR gates pass, dispatch:
 
 ```bash
-gh workflow run publish.yml --ref main -f npm_tag=latest
+VERSION=1.8.2
+MAIN_SHA=$(git rev-parse origin/main)
+gh workflow run publish.yml \
+  --ref main \
+  -f version="$VERSION" \
+  -f commit_sha="$MAIN_SHA" \
+  -f npm_tag=latest
 ```
 
 Use another dist-tag only when explicitly requested. The workflow builds the
-package, publishes the current `main` version through npm trusted publishing,
-pushes `v<new-version>`, and creates the GitHub release. Do not run `npm publish`
-locally as a fallback without separate authorization.
+exact requested commit only after proving it is still current `main` and its
+`package.json` matches the requested version. It then publishes through npm
+trusted publishing, pushes `v<new-version>`, and creates the GitHub release. Do
+not run `npm publish` locally as a fallback without separate authorization.
 
 ## 4. Definitive completion gates
 
@@ -89,6 +98,7 @@ Do not report release success until all of these are independently verified:
 7. Both workflow runs completed successfully.
 
 If publishing succeeds but a later tag or GitHub-release step fails, report the
-partial state exactly. Do not rerun the whole publish workflow because its
-duplicate-package guard will reject the already published version; repair the
-remaining release metadata only with explicit authorization.
+partial state exactly. The workflow can safely resume when the existing npm
+package and tag point to the requested commit and the requested npm dist-tag is
+already correct. It rejects mismatched package, tag, or dist-tag state instead
+of overwriting it; reconcile such a mismatch only with explicit authorization.

--- a/.agents/skills/autoship/references/axie-tools.md
+++ b/.agents/skills/autoship/references/axie-tools.md
@@ -1,0 +1,94 @@
+# Axie Tools Release Workflow
+
+Axie Tools intentionally uses repository-native GitHub Actions instead of
+Changesets. Stock Autoship 0.1.0 can still help frame the release audit, but its
+mutating release command is incompatible because this repository has no
+`@changesets/cli`, `.changeset/config.json`, or `changesets/action` workflow.
+Do not migrate the repository merely to make Autoship run.
+
+## Safety and authorization
+
+- Refresh `origin/main` and tags before deciding the release delta.
+- Preserve unrelated dirty paths. Use a focused branch or isolated worktree and
+  stage exact files only.
+- Do not run the interactive CLI, examples, or live integration tests during a
+  release. They can approve contracts, buy assets, create or cancel orders, or
+  transfer Axies on-chain.
+- Do not request, print, or inspect `PRIVATE_KEY`,
+  `MARKETPLACE_ACCESS_TOKEN`, or `SKYMAVIS_API_KEY`.
+- Treat these as separate mutating boundaries: merging preparatory changes,
+  dispatching the version workflow, merging its PR, and dispatching the publish
+  workflow. Proceed only when the user's current request explicitly authorizes
+  the relevant boundary.
+- Never merge unrelated dependency-update PRs as part of a release.
+
+## 1. Audit and validate
+
+```bash
+git fetch --prune origin --tags
+git log --reverse --oneline v<current-version>..origin/main
+git diff --stat v<current-version>..origin/main
+npm view axie-tools version dist-tags --json
+pnpm install --frozen-lockfile
+pnpm run format:check
+pnpm build
+```
+
+Review the actual commits and diff rather than inferring the bump solely from
+commit prefixes. Confirm that `origin/main`, npm `latest`, and the newest release
+tag all describe the same current version before proceeding.
+
+## 2. Prepare the version PR
+
+After any explicitly authorized preparatory PR is merged and `origin/main` is
+refreshed, dispatch the repository's preparation workflow:
+
+```bash
+gh workflow run release.yml --ref main -f release_type=patch
+```
+
+Use `minor` or `major` only when the audited delta and user authorization call
+for it. The workflow runs `pnpm version --no-git-tag-version`, pushes
+`release/v<new-version>`, and opens a PR containing the `package.json` bump.
+
+Wait for the workflow to complete, then verify the generated PR before merging:
+
+- its base is `main` and head is exactly `release/v<new-version>`;
+- the expected version is present;
+- only `package.json` changed;
+- required CI checks passed.
+
+Merge only that version PR. Refresh `origin/main` and confirm the merged
+`package.json` version before publishing.
+
+## 3. Publish
+
+Publishing is destructive and externally visible. After explicit authorization
+and all version-PR gates pass, dispatch:
+
+```bash
+gh workflow run publish.yml --ref main -f npm_tag=latest
+```
+
+Use another dist-tag only when explicitly requested. The workflow builds the
+package, publishes the current `main` version through npm trusted publishing,
+pushes `v<new-version>`, and creates the GitHub release. Do not run `npm publish`
+locally as a fallback without separate authorization.
+
+## 4. Definitive completion gates
+
+Do not report release success until all of these are independently verified:
+
+1. The version PR is merged.
+2. `package.json` on `origin/main` contains the new version.
+3. `npm view axie-tools@<new-version> version` returns the new version.
+4. `npm view axie-tools dist-tags.latest` returns the new version for a stable
+   release.
+5. Remote tag `v<new-version>` exists and points at the released main commit.
+6. The GitHub release for `v<new-version>` exists.
+7. Both workflow runs completed successfully.
+
+If publishing succeeds but a later tag or GitHub-release step fails, report the
+partial state exactly. Do not rerun the whole publish workflow because its
+duplicate-package guard will reject the already published version; repair the
+remaining release metadata only with explicit authorization.

--- a/.agents/skills/autoship/references/ci-integration.md
+++ b/.agents/skills/autoship/references/ci-integration.md
@@ -1,211 +1,42 @@
-# CI/CD Integration
+# CI integration
 
-Run autoship in CI/CD pipelines for fully automated releases.
+Use stock Autoship in CI only for a configured target that passes the target-
+checkout Changesets gate in `SKILL.md`. Non-Changesets repositories must use a
+reviewed repository-native workflow such as
+[axie-tools.md](axie-tools.md).
 
-## GitHub Actions
+## Required controls
 
-### Scheduled Releases
+- Pin Autoship to the reviewed `0.1.0` release.
+- Resolve and clone the configured target before checking for Changesets.
+- Keep installation in a step with no release credentials.
+- Pass workflow inputs through `env`, quote them, and validate them against
+  explicit repository and release-type allowlists.
+- Restrict label triggers to exact supported labels rather than matching an
+  arbitrary `release:` prefix.
+- Scope `AI_GATEWAY_API_KEY` and `GH_TOKEN` only to the release step.
+- When using the built-in token, map `${{ github.token }}` to `GH_TOKEN` and
+  declare `contents: write` and `pull-requests: write` permissions. Confirm the
+  repository allows Actions to create and approve pull requests.
+- Check out full history with `fetch-depth: 0` before comparing with tags, and
+  handle repositories with no tags explicitly.
+- GitHub-hosted runners already include `gh`; self-hosted runners must install
+  it through their reviewed system-image process.
 
-Release on a schedule (e.g., weekly):
+## Safe workflow shape
 
-```yaml
-name: Scheduled Release
+Keep the workflow repository-specific. A safe sequence is:
 
-on:
-  schedule:
-    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
-  workflow_dispatch:
-    inputs:
-      repo:
-        description: 'Repository to release'
-        required: true
-        type: string
-      type:
-        description: 'Release type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+1. Validate the repository alias and release type without secrets.
+2. Install `autoship@0.1.0` without secrets.
+3. Resolve the alias from `AUTOSHIP_CONFIG`, clone the configured target, and
+   run the three Changesets checks in that checkout.
+4. Stop without mutation when the target is incompatible.
+5. Run `npx autoship@0.1.0` with quoted, validated arguments and release secrets
+   scoped only to that step.
+6. Verify CI, PR merges, npm, dist-tags, tag, release, and source commit before
+   reporting completion.
 
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install autoship
-        run: pnpm add -g autoship
-
-      - name: Configure repository
-        run: |
-          mkdir -p ~/.autoship
-          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
-
-      - name: Run release
-        env:
-          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          autoship ${{ inputs.repo || 'myproject' }} \
-            -t ${{ inputs.type || 'patch' }} \
-            -y
-```
-
-### Trigger on Label
-
-Release when a PR is labeled:
-
-```yaml
-name: Release on Label
-
-on:
-  pull_request:
-    types: [labeled]
-
-jobs:
-  release:
-    if: contains(github.event.label.name, 'release:')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Determine release type
-        id: type
-        run: |
-          LABEL="${{ github.event.label.name }}"
-          if [[ "$LABEL" == "release:major" ]]; then
-            echo "type=major" >> $GITHUB_OUTPUT
-          elif [[ "$LABEL" == "release:minor" ]]; then
-            echo "type=minor" >> $GITHUB_OUTPUT
-          else
-            echo "type=patch" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Install and run autoship
-        env:
-          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          pnpm add -g autoship
-          mkdir -p ~/.autoship
-          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
-          autoship myproject -t ${{ steps.type.outputs.type }} -y
-```
-
-## Environment Variables
-
-Set these secrets in your CI environment:
-
-| Secret | Description |
-|--------|-------------|
-| `AI_GATEWAY_API_KEY` | API key for AI features |
-| `GH_TOKEN` | GitHub token with repo access (or use `GITHUB_TOKEN`) |
-| `AUTOSHIP_CONFIG` | Contents of `~/.autoship/config.json` |
-
-### Creating AUTOSHIP_CONFIG Secret
-
-```bash
-# Copy your local config to clipboard
-cat ~/.autoship/config.json | pbcopy  # macOS
-cat ~/.autoship/config.json | xclip   # Linux
-
-# Add as secret in GitHub repo settings
-```
-
-## Best Practices
-
-### 1. Use Workflow Dispatch for Manual Triggers
-
-Always include `workflow_dispatch` for manual triggering:
-
-```yaml
-on:
-  workflow_dispatch:
-    inputs:
-      type:
-        description: 'Release type'
-        required: true
-        type: choice
-        options: [patch, minor, major]
-```
-
-### 2. Pin autoship Version
-
-For reproducible builds, pin the version:
-
-```yaml
-- run: pnpm add -g autoship@1.0.0
-```
-
-### 3. Validate Before Release
-
-Add a validation step:
-
-```yaml
-- name: Validate
-  run: |
-    # Ensure we have changes to release
-    if git diff --quiet HEAD $(git describe --tags --abbrev=0); then
-      echo "No changes since last release"
-      exit 0
-    fi
-```
-
-### 4. Notify on Completion
-
-```yaml
-- name: Notify
-  if: success()
-  run: |
-    curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
-      -H "Content-Type: application/json" \
-      -d '{"text": "Released ${{ inputs.repo }} (${{ inputs.type }})"}'
-```
-
-## Troubleshooting CI
-
-### "gh: command not found"
-
-Install GitHub CLI in your workflow:
-
-```yaml
-- name: Install GitHub CLI
-  run: |
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-    sudo apt update
-    sudo apt install gh
-```
-
-Or use the official action:
-
-```yaml
-- uses: cli/cli-action@v1
-```
-
-### "Authentication required"
-
-Ensure `GH_TOKEN` is set and has sufficient permissions:
-
-```yaml
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-```
-
-The token needs `repo` scope for private repositories.
+Avoid copying a generic workflow without filling in a repository allowlist and
+reviewing the target's branch rules, npm trusted-publishing configuration, and
+required checks.

--- a/.agents/skills/autoship/references/ci-integration.md
+++ b/.agents/skills/autoship/references/ci-integration.md
@@ -1,0 +1,211 @@
+# CI/CD Integration
+
+Run autoship in CI/CD pipelines for fully automated releases.
+
+## GitHub Actions
+
+### Scheduled Releases
+
+Release on a schedule (e.g., weekly):
+
+```yaml
+name: Scheduled Release
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'Repository to release'
+        required: true
+        type: string
+      type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install autoship
+        run: pnpm add -g autoship
+
+      - name: Configure repository
+        run: |
+          mkdir -p ~/.autoship
+          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
+
+      - name: Run release
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          autoship ${{ inputs.repo || 'myproject' }} \
+            -t ${{ inputs.type || 'patch' }} \
+            -y
+```
+
+### Trigger on Label
+
+Release when a PR is labeled:
+
+```yaml
+name: Release on Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  release:
+    if: contains(github.event.label.name, 'release:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Determine release type
+        id: type
+        run: |
+          LABEL="${{ github.event.label.name }}"
+          if [[ "$LABEL" == "release:major" ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "$LABEL" == "release:minor" ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install and run autoship
+        env:
+          AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          pnpm add -g autoship
+          mkdir -p ~/.autoship
+          echo '${{ secrets.AUTOSHIP_CONFIG }}' > ~/.autoship/config.json
+          autoship myproject -t ${{ steps.type.outputs.type }} -y
+```
+
+## Environment Variables
+
+Set these secrets in your CI environment:
+
+| Secret | Description |
+|--------|-------------|
+| `AI_GATEWAY_API_KEY` | API key for AI features |
+| `GH_TOKEN` | GitHub token with repo access (or use `GITHUB_TOKEN`) |
+| `AUTOSHIP_CONFIG` | Contents of `~/.autoship/config.json` |
+
+### Creating AUTOSHIP_CONFIG Secret
+
+```bash
+# Copy your local config to clipboard
+cat ~/.autoship/config.json | pbcopy  # macOS
+cat ~/.autoship/config.json | xclip   # Linux
+
+# Add as secret in GitHub repo settings
+```
+
+## Best Practices
+
+### 1. Use Workflow Dispatch for Manual Triggers
+
+Always include `workflow_dispatch` for manual triggering:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+```
+
+### 2. Pin autoship Version
+
+For reproducible builds, pin the version:
+
+```yaml
+- run: pnpm add -g autoship@1.0.0
+```
+
+### 3. Validate Before Release
+
+Add a validation step:
+
+```yaml
+- name: Validate
+  run: |
+    # Ensure we have changes to release
+    if git diff --quiet HEAD $(git describe --tags --abbrev=0); then
+      echo "No changes since last release"
+      exit 0
+    fi
+```
+
+### 4. Notify on Completion
+
+```yaml
+- name: Notify
+  if: success()
+  run: |
+    curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+      -H "Content-Type: application/json" \
+      -d '{"text": "Released ${{ inputs.repo }} (${{ inputs.type }})"}'
+```
+
+## Troubleshooting CI
+
+### "gh: command not found"
+
+Install GitHub CLI in your workflow:
+
+```yaml
+- name: Install GitHub CLI
+  run: |
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update
+    sudo apt install gh
+```
+
+Or use the official action:
+
+```yaml
+- uses: cli/cli-action@v1
+```
+
+### "Authentication required"
+
+Ensure `GH_TOKEN` is set and has sufficient permissions:
+
+```yaml
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+The token needs `repo` scope for private repositories.

--- a/.agents/skills/autoship/references/commands.md
+++ b/.agents/skills/autoship/references/commands.md
@@ -1,0 +1,104 @@
+# Command Reference
+
+Complete reference for all autoship commands. For quick start and common patterns, see SKILL.md.
+
+## Main Command
+
+```bash
+autoship [repo] [options]
+```
+
+If `repo` is omitted, displays an interactive selector with all configured repositories.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Release type: `patch`, `minor`, or `major` |
+| `-m, --message <message>` | Custom changeset description (skips AI generation) |
+| `-y, --yes` | Skip all confirmation prompts |
+| `-h, --help` | Show help |
+| `-V, --version` | Show version |
+
+### Examples
+
+```bash
+# Interactive mode - prompts for everything
+autoship myproject
+
+# Specify release type, AI generates message
+autoship myproject -t minor
+
+# Fully automated with custom message
+autoship myproject -t patch -m "Fixed login validation" -y
+
+# Fully automated with AI message
+autoship myproject -t patch -y
+```
+
+## add Command
+
+Add a new repository configuration.
+
+```bash
+autoship add <name>
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Friendly name for the repository (used in other commands) |
+
+### Interactive Prompts
+
+1. **GitHub owner** - Organization or username (required)
+2. **Repository name** - GitHub repository name (defaults to `name`)
+3. **Base branch** - Branch to release from (defaults to `main`)
+
+### Example
+
+```bash
+autoship add myproject
+# > GitHub owner (org or user): vercel-labs
+# > Repository name: myproject
+# > Base branch: main
+# Repository "myproject" added!
+# Clone URL: https://github.com/vercel-labs/myproject.git
+```
+
+## list Command
+
+List all configured repositories.
+
+```bash
+autoship list
+```
+
+### Output
+
+```
+Configured repositories:
+  - myproject (vercel-labs/myproject)
+  - another-lib (vercel-labs/another-lib)
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `AI_GATEWAY_API_KEY` | API key for AI-powered suggestions and descriptions | Yes |
+| `GITHUB_TOKEN` | GitHub token (uses `gh` CLI auth by default) | No |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Error (see output for details) |
+
+Common error scenarios:
+- Repository not configured
+- GitHub CLI not authenticated
+- CI checks failed
+- AI API unavailable (falls back to manual input)

--- a/.agents/skills/autoship/references/commands.md
+++ b/.agents/skills/autoship/references/commands.md
@@ -1,104 +1,54 @@
-# Command Reference
+# Command reference
 
-Complete reference for all autoship commands. For quick start and common patterns, see SKILL.md.
-
-## Main Command
+Use the reviewed CLI version explicitly:
 
 ```bash
-autoship [repo] [options]
+npx autoship@0.1.0 [repo] [options]
 ```
 
-If `repo` is omitted, displays an interactive selector with all configured repositories.
+If `repo` is omitted, Autoship prompts for a configured alias.
 
-### Options
+## Release options
 
-| Option | Description |
-|--------|-------------|
-| `-t, --type <type>` | Release type: `patch`, `minor`, or `major` |
-| `-m, --message <message>` | Custom changeset description (skips AI generation) |
-| `-y, --yes` | Skip all confirmation prompts |
-| `-h, --help` | Show help |
-| `-V, --version` | Show version |
+- `-t, --type <type>` selects `patch`, `minor`, or `major`.
+- `-m, --message <message>` supplies reviewed release text and skips AI text
+  generation.
+- `-y, --yes` skips Autoship confirmations. It does not grant authorization.
+- `-h, --help` displays help.
+- `-V, --version` displays the installed version.
 
-### Examples
+Run the target-checkout compatibility gate in `SKILL.md` before any release.
 
 ```bash
-# Interactive mode - prompts for everything
-autoship myproject
+# Interactive release
+npx autoship@0.1.0 myproject
 
-# Specify release type, AI generates message
-autoship myproject -t minor
-
-# Fully automated with custom message
-autoship myproject -t patch -m "Fixed login validation" -y
-
-# Fully automated with AI message
-autoship myproject -t patch -y
+# Authorized patch with reviewed release text
+npx autoship@0.1.0 myproject -t patch -m "Fix login validation" -y
 ```
 
-## add Command
-
-Add a new repository configuration.
+## Repository configuration
 
 ```bash
-autoship add <name>
+npx autoship@0.1.0 add myproject
+npx autoship@0.1.0 list
 ```
 
-### Arguments
+`add` prompts for the GitHub owner, repository, and base branch. Configuration
+is stored in `~/.autoship/config.json`.
 
-| Argument | Description |
-|----------|-------------|
-| `name` | Friendly name for the repository (used in other commands) |
+Typical list output:
 
-### Interactive Prompts
-
-1. **GitHub owner** - Organization or username (required)
-2. **Repository name** - GitHub repository name (defaults to `name`)
-3. **Base branch** - Branch to release from (defaults to `main`)
-
-### Example
-
-```bash
-autoship add myproject
-# > GitHub owner (org or user): vercel-labs
-# > Repository name: myproject
-# > Base branch: main
-# Repository "myproject" added!
-# Clone URL: https://github.com/vercel-labs/myproject.git
-```
-
-## list Command
-
-List all configured repositories.
-
-```bash
-autoship list
-```
-
-### Output
-
-```
+```text
 Configured repositories:
-  - myproject (vercel-labs/myproject)
-  - another-lib (vercel-labs/another-lib)
+  - myproject (example-owner/example-repo)
 ```
 
-## Environment Variables
+## Environment
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `AI_GATEWAY_API_KEY` | API key for AI-powered suggestions and descriptions | Yes |
-| `GITHUB_TOKEN` | GitHub token (uses `gh` CLI auth by default) | No |
+- `AI_GATEWAY_API_KEY` is required only when `-m` is omitted.
+- `GH_TOKEN` is optional when the local `gh` CLI is already authenticated.
 
-## Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | Error (see output for details) |
-
-Common error scenarios:
-- Repository not configured
-- GitHub CLI not authenticated
-- CI checks failed
-- AI API unavailable (falls back to manual input)
+Autoship exits nonzero for missing configuration, authentication failures,
+failed checks, or an unavailable AI service. Treat a nonzero result and any
+partially completed publish as state to audit, not as permission to retry.

--- a/.agents/skills/autoship/references/configuration.md
+++ b/.agents/skills/autoship/references/configuration.md
@@ -1,0 +1,124 @@
+# Configuration Reference
+
+autoship stores configuration in `~/.autoship/config.json`.
+
+## Config File Structure
+
+```json
+{
+  "repos": {
+    "<name>": {
+      "owner": "<github-owner>",
+      "repo": "<github-repo>",
+      "baseBranch": "<branch>",
+      "cloneUrl": "<clone-url>"
+    }
+  }
+}
+```
+
+## Repository Configuration
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | string | GitHub organization or username |
+| `repo` | string | GitHub repository name |
+| `baseBranch` | string | Branch to create releases from (typically `main`) |
+| `cloneUrl` | string | HTTPS clone URL (auto-generated) |
+
+### Example
+
+```json
+{
+  "repos": {
+    "ai-sdk": {
+      "owner": "vercel",
+      "repo": "ai",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel/ai.git"
+    },
+    "agent-browser": {
+      "owner": "vercel-labs",
+      "repo": "agent-browser",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/vercel-labs/agent-browser.git"
+    }
+  }
+}
+```
+
+## Managing Configuration
+
+### Add Repository (Recommended)
+
+Use the CLI to add repositories:
+
+```bash
+autoship add myproject
+```
+
+This interactively prompts for all required fields.
+
+### Manual Editing
+
+You can also edit `~/.autoship/config.json` directly:
+
+```bash
+# Open config file
+$EDITOR ~/.autoship/config.json
+```
+
+### Remove Repository
+
+Currently, remove repositories by editing the config file directly:
+
+```bash
+# Edit and remove the entry from "repos"
+$EDITOR ~/.autoship/config.json
+```
+
+## Requirements for Target Repositories
+
+autoship works with repositories that use the [changesets](https://github.com/changesets/changesets) workflow:
+
+1. **Changesets installed** - `@changesets/cli` as dev dependency
+2. **Changesets config** - `.changeset/config.json` exists
+3. **Changesets GitHub Action** - Configured to create Version Packages PRs
+4. **Version tags** - Repository uses version tags (e.g., `v1.2.3`, `package@1.2.3`)
+
+### Typical Target Repository Setup
+
+```bash
+# In the target repository
+pnpm add -D @changesets/cli
+npx changeset init
+```
+
+`.github/workflows/release.yml`:
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - uses: changesets/action@v1
+        with:
+          publish: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```

--- a/.agents/skills/autoship/references/configuration.md
+++ b/.agents/skills/autoship/references/configuration.md
@@ -1,124 +1,35 @@
-# Configuration Reference
+# Configuration reference
 
-autoship stores configuration in `~/.autoship/config.json`.
-
-## Config File Structure
+Autoship stores repository aliases in `~/.autoship/config.json`:
 
 ```json
 {
   "repos": {
-    "<name>": {
-      "owner": "<github-owner>",
-      "repo": "<github-repo>",
-      "baseBranch": "<branch>",
-      "cloneUrl": "<clone-url>"
+    "myproject": {
+      "owner": "example-owner",
+      "repo": "example-repo",
+      "baseBranch": "main",
+      "cloneUrl": "https://github.com/example-owner/example-repo.git"
     }
   }
 }
 ```
 
-## Repository Configuration
+Use `npx autoship@0.1.0 add <name>` for interactive setup or the bundled
+`templates/setup-repo.sh` for non-interactive setup. Do not print the config in
+CI when it is supplied as a secret.
 
-### Fields
+## Target requirements
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `owner` | string | GitHub organization or username |
-| `repo` | string | GitHub repository name |
-| `baseBranch` | string | Branch to create releases from (typically `main`) |
-| `cloneUrl` | string | HTTPS clone URL (auto-generated) |
+Stock Autoship is authorized only when the configured target checkout has:
 
-### Example
+1. `@changesets/cli` in `devDependencies`.
+2. `.changeset/config.json`.
+3. A workflow that invokes `changesets/action`.
+4. Version tags that Autoship can compare.
 
-```json
-{
-  "repos": {
-    "ai-sdk": {
-      "owner": "vercel",
-      "repo": "ai",
-      "baseBranch": "main",
-      "cloneUrl": "https://github.com/vercel/ai.git"
-    },
-    "agent-browser": {
-      "owner": "vercel-labs",
-      "repo": "agent-browser",
-      "baseBranch": "main",
-      "cloneUrl": "https://github.com/vercel-labs/agent-browser.git"
-    }
-  }
-}
-```
-
-## Managing Configuration
-
-### Add Repository (Recommended)
-
-Use the CLI to add repositories:
-
-```bash
-autoship add myproject
-```
-
-This interactively prompts for all required fields.
-
-### Manual Editing
-
-You can also edit `~/.autoship/config.json` directly:
-
-```bash
-# Open config file
-$EDITOR ~/.autoship/config.json
-```
-
-### Remove Repository
-
-Currently, remove repositories by editing the config file directly:
-
-```bash
-# Edit and remove the entry from "repos"
-$EDITOR ~/.autoship/config.json
-```
-
-## Requirements for Target Repositories
-
-autoship works with repositories that use the [changesets](https://github.com/changesets/changesets) workflow:
-
-1. **Changesets installed** - `@changesets/cli` as dev dependency
-2. **Changesets config** - `.changeset/config.json` exists
-3. **Changesets GitHub Action** - Configured to create Version Packages PRs
-4. **Version tags** - Repository uses version tags (e.g., `v1.2.3`, `package@1.2.3`)
-
-### Typical Target Repository Setup
-
-```bash
-# In the target repository
-pnpm add -D @changesets/cli
-npx changeset init
-```
-
-`.github/workflows/release.yml`:
-```yaml
-name: Release
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install
-      - uses: changesets/action@v1
-        with:
-          publish: pnpm release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-```
+The target's Changesets workflow must independently use reviewed, commit-pinned
+Actions, declare only the permissions it needs, and configure npm publishing
+according to that repository's security model. This skill deliberately avoids
+shipping a generic privileged workflow: copy the target's existing conventions
+or follow current official Changesets and GitHub Actions documentation.

--- a/.agents/skills/autoship/templates/automated-release.sh
+++ b/.agents/skills/autoship/templates/automated-release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Template: Automated Release
+# Purpose: Fully automated release with no prompts
+# Usage: ./automated-release.sh <repo-name> <release-type> [message]
+#
+# Examples:
+#   ./automated-release.sh myproject patch
+#   ./automated-release.sh myproject minor
+#   ./automated-release.sh myproject major "Breaking API changes"
+
+set -euo pipefail
+
+REPO="${1:?Usage: $0 <repo-name> <release-type> [message]}"
+TYPE="${2:?Usage: $0 <repo-name> <release-type> [message]}"
+MESSAGE="${3:-}"
+
+# Validate release type
+if [[ ! "$TYPE" =~ ^(patch|minor|major)$ ]]; then
+  echo "Error: release type must be patch, minor, or major"
+  exit 1
+fi
+
+# Check requirements
+if ! command -v gh &> /dev/null; then
+  echo "Error: GitHub CLI (gh) is required"
+  echo "Install: https://cli.github.com"
+  exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+  echo "Error: GitHub CLI not authenticated"
+  echo "Run: gh auth login"
+  exit 1
+fi
+
+if [[ -z "${AI_GATEWAY_API_KEY:-}" ]]; then
+  echo "Error: AI_GATEWAY_API_KEY environment variable not set"
+  exit 1
+fi
+
+# Run autoship
+echo "Starting $TYPE release for $REPO..."
+
+if [[ -n "$MESSAGE" ]]; then
+  autoship "$REPO" -t "$TYPE" -m "$MESSAGE" -y
+else
+  autoship "$REPO" -t "$TYPE" -y
+fi
+
+echo "Release complete!"

--- a/.agents/skills/autoship/templates/automated-release.sh
+++ b/.agents/skills/autoship/templates/automated-release.sh
@@ -33,7 +33,7 @@ if ! gh auth status &> /dev/null; then
   exit 1
 fi
 
-if [[ -z "${AI_GATEWAY_API_KEY:-}" ]]; then
+if [[ -z "$MESSAGE" && -z "${AI_GATEWAY_API_KEY:-}" ]]; then
   echo "Error: AI_GATEWAY_API_KEY environment variable not set"
   exit 1
 fi
@@ -42,9 +42,9 @@ fi
 echo "Starting $TYPE release for $REPO..."
 
 if [[ -n "$MESSAGE" ]]; then
-  autoship "$REPO" -t "$TYPE" -m "$MESSAGE" -y
+  npx autoship@0.1.0 "$REPO" -t "$TYPE" -m "$MESSAGE" -y
 else
-  autoship "$REPO" -t "$TYPE" -y
+  npx autoship@0.1.0 "$REPO" -t "$TYPE" -y
 fi
 
 echo "Release complete!"

--- a/.agents/skills/autoship/templates/setup-repo.sh
+++ b/.agents/skills/autoship/templates/setup-repo.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Template: Non-interactive Repository Setup
+# Purpose: Add a repository without interactive prompts
+# Usage: ./setup-repo.sh <name> <owner> <repo> [base-branch]
+#
+# Examples:
+#   ./setup-repo.sh myproject vercel-labs myproject
+#   ./setup-repo.sh myproject vercel-labs myproject main
+#   ./setup-repo.sh ai-sdk vercel ai main
+
+set -euo pipefail
+
+NAME="${1:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+OWNER="${2:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+REPO="${3:?Usage: $0 <name> <owner> <repo> [base-branch]}"
+BASE_BRANCH="${4:-main}"
+
+CONFIG_DIR="$HOME/.autoship"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+# Create config directory if needed
+mkdir -p "$CONFIG_DIR"
+
+# Initialize config file if needed
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo '{"repos":{}}' > "$CONFIG_FILE"
+fi
+
+# Check if jq is available for JSON manipulation
+if command -v jq &> /dev/null; then
+  # Use jq for proper JSON handling
+  CLONE_URL="https://github.com/$OWNER/$REPO.git"
+
+  jq --arg name "$NAME" \
+     --arg owner "$OWNER" \
+     --arg repo "$REPO" \
+     --arg branch "$BASE_BRANCH" \
+     --arg url "$CLONE_URL" \
+     '.repos[$name] = {owner: $owner, repo: $repo, baseBranch: $branch, cloneUrl: $url}' \
+     "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+
+  echo "Repository '$NAME' added!"
+  echo "  Owner: $OWNER"
+  echo "  Repo: $REPO"
+  echo "  Branch: $BASE_BRANCH"
+  echo "  Clone URL: $CLONE_URL"
+else
+  # Fallback: use autoship add with expect-like input
+  echo "Warning: jq not found, using interactive fallback"
+  echo "Install jq for non-interactive setup: brew install jq"
+  echo ""
+  echo "Running: autoship add $NAME"
+  echo "Please enter:"
+  echo "  Owner: $OWNER"
+  echo "  Repo: $REPO"
+  echo "  Branch: $BASE_BRANCH"
+  autoship add "$NAME"
+fi

--- a/.agents/skills/autoship/templates/setup-repo.sh
+++ b/.agents/skills/autoship/templates/setup-repo.sh
@@ -26,33 +26,32 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   echo '{"repos":{}}' > "$CONFIG_FILE"
 fi
 
-# Check if jq is available for JSON manipulation
-if command -v jq &> /dev/null; then
-  # Use jq for proper JSON handling
-  CLONE_URL="https://github.com/$OWNER/$REPO.git"
-
-  jq --arg name "$NAME" \
-     --arg owner "$OWNER" \
-     --arg repo "$REPO" \
-     --arg branch "$BASE_BRANCH" \
-     --arg url "$CLONE_URL" \
-     '.repos[$name] = {owner: $owner, repo: $repo, baseBranch: $branch, cloneUrl: $url}' \
-     "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
-
-  echo "Repository '$NAME' added!"
-  echo "  Owner: $OWNER"
-  echo "  Repo: $REPO"
-  echo "  Branch: $BASE_BRANCH"
-  echo "  Clone URL: $CLONE_URL"
-else
-  # Fallback: use autoship add with expect-like input
-  echo "Warning: jq not found, using interactive fallback"
-  echo "Install jq for non-interactive setup: brew install jq"
-  echo ""
-  echo "Running: autoship add $NAME"
-  echo "Please enter:"
-  echo "  Owner: $OWNER"
-  echo "  Repo: $REPO"
-  echo "  Branch: $BASE_BRANCH"
-  autoship add "$NAME"
+# jq is required because autoship add is interactive.
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required for non-interactive setup" >&2
+  exit 1
 fi
+
+CLONE_URL="https://github.com/$OWNER/$REPO.git"
+TEMP_CONFIG="$CONFIG_FILE.tmp.$$"
+trap 'rm -f "$TEMP_CONFIG"' EXIT
+
+if ! jq --arg name "$NAME" \
+   --arg owner "$OWNER" \
+   --arg repo "$REPO" \
+   --arg branch "$BASE_BRANCH" \
+   --arg url "$CLONE_URL" \
+   '.repos[$name] = {owner: $owner, repo: $repo, baseBranch: $branch, cloneUrl: $url}' \
+   "$CONFIG_FILE" > "$TEMP_CONFIG"; then
+  echo "Error: failed to update Autoship configuration" >&2
+  exit 1
+fi
+
+mv "$TEMP_CONFIG" "$CONFIG_FILE"
+trap - EXIT
+
+echo "Repository '$NAME' added!"
+echo "  Owner: $OWNER"
+echo "  Repo: $REPO"
+echo "  Branch: $BASE_BRANCH"
+echo "  Clone URL: $CLONE_URL"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "autoship": {
+      "source": "vercel-labs/autoship",
+      "sourceType": "github",
+      "skillPath": "skills/autoship/SKILL.md",
+      "computedHash": "a813370b550f6b2a7c0dceba1c2f3c06978b10e4bbfbcf39421220d8140ab220"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- install the project-local Autoship skill
- add a compatibility preflight for repositories without Changesets
- document Axie Tools' existing version-PR and trusted-publish workflows
- make publish authorization, live marketplace safety, and definitive verification gates explicit

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run format:check`
- `pnpm build`
- `npx --yes autoship --version` (0.1.0)
- `npx --yes autoship list` (confirmed no configured repositories)
- Changesets probes confirmed no CLI, config, or action

No on-chain examples, CLI flows, or credential-dependent tests were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable templates for automated releases and noninteractive repository setup.
  * Added version-pinned Autoship skill metadata for consistent tooling.
  * Added specialized guidance for repositories using native GitHub Actions release workflows.

* **Documentation**
  * Added comprehensive documentation for Autoship workflows, commands, configuration, CI/CD integration, troubleshooting, environment variables, authorization requirements, safety boundaries, and completion criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->