### PR TITLE
fix(release): enforce Autoship safety gates

### DIFF
--- a/.agents/skills/autoship/SKILL.md
+++ b/.agents/skills/autoship/SKILL.md
@@ -75,5 +75,6 @@ The patch release has been published.
 
 - [templates/setup-repo.sh](templates/setup-repo.sh) writes configuration
   non-interactively and requires `jq`.
-- [templates/automated-release.sh](templates/automated-release.sh) runs an
-  already-authorized compatible release with Autoship 0.1.0.
+- [templates/automated-release.sh](templates/automated-release.sh) requires an
+  explicit authorization marker and independently checks the configured target
+  before running a compatible release with Autoship 0.1.0.

--- a/.agents/skills/autoship/references/commands.md
+++ b/.agents/skills/autoship/references/commands.md
@@ -52,3 +52,7 @@ Configured repositories:
 Autoship exits nonzero for missing configuration, authentication failures,
 failed checks, or an unavailable AI service. Treat a nonzero result and any
 partially completed publish as state to audit, not as permission to retry.
+
+The bundled automated template additionally requires
+`AUTOSHIP_RELEASE_AUTHORIZED=yes` and repeats the configured-target
+compatibility checks before invoking Autoship.

--- a/.agents/skills/autoship/templates/automated-release.sh
+++ b/.agents/skills/autoship/templates/automated-release.sh
@@ -2,6 +2,7 @@
 # Template: Automated Release
 # Purpose: Fully automated release with no prompts
 # Usage: ./automated-release.sh <repo-name> <release-type> [message]
+# Requires: AUTOSHIP_RELEASE_AUTHORIZED=yes after the release is approved.
 #
 # Examples:
 #   ./automated-release.sh myproject patch
@@ -13,6 +14,12 @@ set -euo pipefail
 REPO="${1:?Usage: $0 <repo-name> <release-type> [message]}"
 TYPE="${2:?Usage: $0 <repo-name> <release-type> [message]}"
 MESSAGE="${3:-}"
+CONFIG_FILE="${AUTOSHIP_CONFIG:-$HOME/.autoship/config.json}"
+
+if [[ "${AUTOSHIP_RELEASE_AUTHORIZED:-}" != "yes" ]]; then
+  echo "Error: set AUTOSHIP_RELEASE_AUTHORIZED=yes only after this release is approved" >&2
+  exit 1
+fi
 
 # Validate release type
 if [[ ! "$TYPE" =~ ^(patch|minor|major)$ ]]; then
@@ -27,6 +34,16 @@ if ! command -v gh &> /dev/null; then
   exit 1
 fi
 
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required to validate the configured target" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Error: Autoship configuration not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
 if ! gh auth status &> /dev/null; then
   echo "Error: GitHub CLI not authenticated"
   echo "Run: gh auth login"
@@ -35,6 +52,26 @@ fi
 
 if [[ -z "$MESSAGE" && -z "${AI_GATEWAY_API_KEY:-}" ]]; then
   echo "Error: AI_GATEWAY_API_KEY environment variable not set"
+  exit 1
+fi
+
+CLONE_URL=$(jq -er --arg repo "$REPO" '.repos[$repo].cloneUrl | strings | select(length > 0)' "$CONFIG_FILE") || {
+  echo "Error: repository '$REPO' has no cloneUrl in $CONFIG_FILE" >&2
+  exit 1
+}
+BASE_BRANCH=$(jq -er --arg repo "$REPO" '.repos[$repo].baseBranch | strings | select(length > 0)' "$CONFIG_FILE") || {
+  echo "Error: repository '$REPO' has no baseBranch in $CONFIG_FILE" >&2
+  exit 1
+}
+
+TARGET_DIR=$(mktemp -d)
+trap 'rm -rf "$TARGET_DIR"' EXIT
+git clone --quiet --depth 1 --branch "$BASE_BRANCH" --single-branch "$CLONE_URL" "$TARGET_DIR"
+
+if ! test -f "$TARGET_DIR/.changeset/config.json" ||
+   ! (cd "$TARGET_DIR" && node -e "const p=require('./package.json'); process.exit(p.devDependencies?.['@changesets/cli'] ? 0 : 1)") ||
+   ! rg -q 'changesets/action' "$TARGET_DIR/.github/workflows"; then
+  echo "Error: configured target is not compatible with stock Autoship" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- require an explicit authorization marker before the automated Autoship template can publish
- resolve and clone the configured target, then repeat the Changesets compatibility gate
- document the template's authorization and compatibility behavior

## Validation
- `bash -n .agents/skills/autoship/templates/automated-release.sh .agents/skills/autoship/templates/setup-repo.sh`
- `shellcheck .agents/skills/autoship/templates/automated-release.sh .agents/skills/autoship/templates/setup-repo.sh`
- `npx --yes skills list --json`
- denial-path check without `AUTOSHIP_RELEASE_AUTHORIZED=yes`
- `git diff --check`